### PR TITLE
fix compatibility for header class

### DIFF
--- a/src/Http/Headers.php
+++ b/src/Http/Headers.php
@@ -2,6 +2,8 @@
 
 namespace Timiki\RpcCommon\Http;
 
+use Traversable;
+
 class Headers implements \IteratorAggregate, \Countable
 {
     protected $headers = [];
@@ -117,7 +119,7 @@ class Headers implements \IteratorAggregate, \Countable
      *
      * @return \ArrayIterator An \ArrayIterator instance
      */
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         return new \ArrayIterator($this->headers);
     }
@@ -127,7 +129,7 @@ class Headers implements \IteratorAggregate, \Countable
      *
      * @return int The number of headers
      */
-    public function count()
+    public function count(): int
     {
         return \count($this->headers);
     }


### PR DESCRIPTION
issues:
Deprecated: Return type of Timiki\RpcCommon\Http\Headers::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice

Deprecated: Return type of Timiki\RpcCommon\Http\Headers::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice