### PR TITLE
Fix 8.4 nullable deprecations

### DIFF
--- a/src/JsonRequest.php
+++ b/src/JsonRequest.php
@@ -31,7 +31,7 @@ class JsonRequest extends JsonHttp implements \JsonSerializable
      */
     protected JsonResponse|null $response = null;
 
-    public function __construct(string $method, array $params = [], string|int|float $id = null)
+    public function __construct(string $method, array $params = [], string|int|float|null $id = null)
     {
         $this->method = $method;
         $this->params = $params;

--- a/src/JsonResponse.php
+++ b/src/JsonResponse.php
@@ -46,7 +46,7 @@ class JsonResponse extends JsonHttp implements \JsonSerializable
      */
     protected JsonRequest|null $request = null;
 
-    public function __construct(JsonRequest $jsonRequest = null)
+    public function __construct(JsonRequest|null $jsonRequest = null)
     {
         if ($jsonRequest) {
             $this->setRequest($jsonRequest);


### PR DESCRIPTION
Added the missing null type to solve the deprecation notification

Implicitly marking parameter $value as nullable is deprecated, the explicit nullable type must be used instead

Source: https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated